### PR TITLE
enable LTO

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ SOURCE  := source
 BUILD   := build
 INCDIR	:= include
 SUBARCH := -mcpu=arm946e-s -mfloat-abi=soft -marm -mno-thumb-interwork \
-			-ggdb -nostdlib -ffreestanding -nostartfiles -lgcc
+	-ggdb -nostdlib -ffreestanding -nostartfiles -lgcc -flto
 
 DBG_FLAG :=
 # ifneq ($(RELEASE),)

--- a/include/arm/arm.h
+++ b/include/arm/arm.h
@@ -135,8 +135,8 @@ static inline void arm_wait_for_interrupt(void) {
 static inline u32 arm_swp(u32 val, u32 *addr) {
 	u32 old;
 	asmv(
-		"swp %0, %1, [ %2 ]\n\t"
-		: "=r"(old) : "r"(val), "r"(addr) : "memory"
+		"swp %0, %1, [%2]\n\t"
+		: "=&r"(old) : "r"(val), "r"(addr) : "memory"
 	);
 	return old;
 }
@@ -145,8 +145,8 @@ static inline u32 arm_swp(u32 val, u32 *addr) {
 static inline u32 arm_swpb(u8 val, u8 *addr) {
 	u32 old;
 	asmv(
-		"swpb %0, %1, [ %2 ]\n\t"
-		: "=r"(old) : "r"(val), "r"(addr) : "memory"
+		"swpb %0, %1, [%2]\n\t"
+		: "=&r"(old) : "r"(val), "r"(addr) : "memory"
 	);
 	return old;
 }

--- a/include/common.h
+++ b/include/common.h
@@ -68,7 +68,6 @@ typedef volatile s64 vs64;
 #define ATTR_USED	__attribute__((used))
 #define APACKED(x)	__attribute__((packed, aligned(x)))
 #define PACKED	APACKED(4) /* defaults to 4 byte alignment */
-#define UNUSED	__attribute__((unused))
 
 #define NORETURN	__attribute__((noreturn))
 #define ALIGNED(n)	__attribute__((aligned(n)))
@@ -77,5 +76,8 @@ typedef volatile s64 vs64;
 #define UNLIKELY(x)	__builtin_expect(!!(x), 0)
 
 #define SECTION(s)	__attribute__((section(s)))
+
+#define KEEP	__attribute__((used))
+#define UNUSED	__attribute__((unused))
 
 #endif // __ASSEMBLER__

--- a/include/virt/manager.h
+++ b/include/virt/manager.h
@@ -36,8 +36,8 @@ typedef struct vqueue_s vqueue_s;
 	@pbuf	- prBuf function pointer
 */
 #define DECLARE_VIRTDEV(name, prv, dclass, feat, vn, hrst, rcfg, wcfg, pbuf) \
-	vqueue_s name##_vqs[vn]; \
-	vdev_s name = { \
+	vqueue_s KEEP name##_vqs[vn]; \
+	vdev_s KEEP name = { \
 		.dev_id = (dclass), \
 		.status = 0, \
 		.cfg = 0, \
@@ -51,7 +51,7 @@ typedef struct vqueue_s vqueue_s;
 		.vqn = (vn), \
 		.priv = (prv) \
 	}; \
-	const u32 SECTION(".vdev_list") name##_entry = (u32)(&name);
+	const u32 KEEP SECTION(".vdev_list") name##_entry = (u32)(&name);
 
 /**
 	Initialize device array. MUST be done only once on boot


### PR DESCRIPTION
tested only with the default arm toolchain provided in ubuntu 20.04, so it needs further testing by people in other distros

it generates a much smaller and efficient binary, with no changes to the sdmmc code I can see a ~15% improvement, which could be compounded on top of unrolling and other optimizations